### PR TITLE
Fix loses part of the response text when plugin printing generated responses

### DIFF
--- a/scripts/result/common.js
+++ b/scripts/result/common.js
@@ -98,8 +98,11 @@ async function readStream(response, feature, language = '') {
                     if (line.includes('[DONE]')) {
                         await chrome.runtime.sendMessage({ source: 'stream', status: 'finished' });
                     } else {
-                        if (line.startsWith('data')) {
-                            const possibleJSON = line.slice(6);
+                        if (line.startsWith('data') || isCompleteJSON(line)) {
+                            let possibleJSON = line;
+                            if (line.startsWith('data')) {
+                                possibleJSON = line.slice(6);
+                            }
                             if (isCompleteJSON(possibleJSON)) {
                                 const json = JSON.parse(possibleJSON);
                                 if (json.choices[0].finish_reason != null) {


### PR DESCRIPTION
Fix loses part of the response text when plugin printing generated responses.
This PR fixing this issue: https://github.com/TestCraft-App/test-craft-app-v1/issues/14